### PR TITLE
revisions to get it to install on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
 
 # print install log
 after_failure:
- - cat "${RCHECK_DIR}/00install.out"
+ - cat /home/travis/build/kbroman/qtl2/qtl2.Rcheck/00install.out
 
 after_success:
- - cat "${RCHECK_DIR}/00install.out"
+ - cat /home/travis/build/kbroman/qtl2/qtl2.Rcheck/00install.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,10 @@ script:
   - |
     R CMD build .
     travis_wait 20 R CMD check --as-cran qtl2_*.tar.gz
+
+# print install log
+after_failure:
+ - cat "${RCHECK_DIR}/00install.out"
+
+after_success:
+ - cat "${RCHECK_DIR}/00install.out"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
 
 # print install log
 after_failure:
- - cat /home/travis/build/kbroman/qtl2/qtl2.Rcheck/00install.out
+ - cat qtl2.Rcheck/00install.out
 
 after_success:
- - cat /home/travis/build/kbroman/qtl2/qtl2.Rcheck/00install.out
+ - cat qtl2.Rcheck/00install.out

--- a/src/cross.cpp
+++ b/src/cross.cpp
@@ -45,16 +45,14 @@ QTLCross* QTLCross::Create(const String& crosstype)
     if(crosstype_str.length() > 6 && crosstype_str.substr(0,6).compare("genril")==0) {
         int n_char = crosstype_str.length();
         std::string str_n_founders = crosstype_str.substr(6, n_char-6);
-        std::string::size_type sz;
-        int n_founders = std::stoi(str_n_founders, &sz);
+        int n_founders = std::atoi(str_n_founders.c_str());
         return new GENRIL(n_founders);
     }
 
     if(crosstype_str.length() > 6 && crosstype_str.substr(0,6).compare("genail")==0) {
         int n_char = crosstype_str.length();
         std::string str_n_founders = crosstype_str.substr(6, n_char-6);
-        std::string::size_type sz;
-        int n_founders = std::stoi(str_n_founders, &sz);
+        int n_founders = std::atoi(str_n_founders.c_str());
         return new GENAIL(n_founders);
     }
 


### PR DESCRIPTION
need to change `std::stoi()` to `std::atoi()` because the former needs c++11.

also needed to print install logs to see the error.